### PR TITLE
feat: set default generic to Record<string, never>

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // https://github.com/libp2p/js-libp2p/issues/1269#issue-1280763716
-export class CodeError<T extends Record<string, any>> extends Error {
+export class CodeError<T extends Record<string, any> = Record<string, never>> extends Error {
   code: string
   props: T
 


### PR DESCRIPTION
Setting the default generic type for props allows the type to be correct when no props are used.

```ts
const err = new CodeError('foo', 'bar')

err.props // <- now is properly typed as Record<string, never>
```